### PR TITLE
DESCW-3169 Fixes bug where the pattern scan ran even if the 'patterns…

### DIFF
--- a/.github/workflows/pattern-validate.yml
+++ b/.github/workflows/pattern-validate.yml
@@ -23,12 +23,11 @@ jobs:
       - name: Install dependencies
         run: composer install
 
-      - name: Check patterns directory
+      - name: Scan patterns directory
         run: |
           if [ ! -d patterns ]; then
             echo "No patterns directory found, skipping validation"
             exit 0
           fi
+          composer scan-wp-patterns
 
-      - name: Scan WordPress patterns
-        run: composer scan-wp-patterns


### PR DESCRIPTION
This pull request updates the workflow for validating WordPress patterns in `.github/workflows/pattern-validate.yml`. The main change is a simplification of the steps for scanning the patterns directory.

Workflow improvements:

* Renamed the step from "Check patterns directory" to "Scan patterns directory" and moved the `composer scan-wp-patterns` command into this step, removing the separate "Scan WordPress patterns" step for clarity and efficiency.…' directory is missing