### PR TITLE
DESCW-3192 adds basic permissions for the linting workflow

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,18 +1,19 @@
 name: Linting
-
 on:
   workflow_call:
   workflow_dispatch:
 
 jobs:
   linting:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install Node.js 20
-        uses: actions/setup-node@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for linting to improve security and keep dependencies up to date. The most important changes are grouped below:

Dependency updates:

* Upgraded the `actions/checkout` action from version 2 to version 4 in the `linting.yml` workflow file.
* Upgraded the `actions/setup-node` action from version 3 to version 4 in the `linting.yml` workflow file.

Security improvements:

* Added explicit `permissions` for the workflow job, granting read-only access to repository contents.